### PR TITLE
feat: add interactive quiz generator

### DIFF
--- a/quiz.html
+++ b/quiz.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Générateur de Quiz IA</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet" />
+</head>
+<body class="bg-gray-100 font-sans">
+  <main class="max-w-5xl mx-auto p-4">
+    <h1 class="text-3xl font-bold text-center mb-6">Générateur de Quiz IA</h1>
+
+    <section class="bg-white p-4 rounded shadow mb-6" id="create-quiz">
+      <h2 class="text-xl font-semibold mb-2">Créer un nouveau quiz</h2>
+      <label class="block mb-2">Texte du cours ou chapitre :</label>
+      <textarea id="course-text" class="w-full border rounded p-2 mb-4" rows="5" placeholder="Collez ici votre cours..."></textarea>
+
+      <div class="flex flex-wrap gap-4 mb-4">
+        <div>
+          <label class="block mb-1">Nombre de questions :</label>
+          <input id="question-count" type="number" min="1" class="border rounded p-2 w-32" />
+          <p class="text-xs text-gray-500">Laissez vide pour couvrir tout le sujet</p>
+        </div>
+
+        <div>
+          <label class="block mb-1">Dossier :</label>
+          <select id="folder-select" class="border rounded p-2">
+            <option value="">(aucun)</option>
+          </select>
+        </div>
+
+        <div class="flex items-end">
+          <button id="new-folder-btn" class="bg-blue-500 text-white px-3 py-2 rounded">Nouveau dossier</button>
+        </div>
+      </div>
+
+      <button id="generate-btn" class="bg-green-600 text-white px-4 py-2 rounded">Générer le quiz</button>
+    </section>
+
+    <section id="quiz-container" class="space-y-4"></section>
+
+    <section id="score-section" class="text-center text-lg font-semibold mt-6 hidden"></section>
+
+    <section class="mt-10">
+      <h2 class="text-xl font-semibold mb-2">Vos dossiers</h2>
+      <ul id="folder-list" class="list-disc pl-6"></ul>
+    </section>
+  </main>
+
+  <script src="quiz.js"></script>
+</body>
+</html>

--- a/quiz.js
+++ b/quiz.js
@@ -1,0 +1,151 @@
+// Générateur de quiz utilisant l'API Gemini
+// Cette version utilise des données simulées pour éviter d'exposer une clé API.
+
+const courseText = document.getElementById('course-text');
+const questionCount = document.getElementById('question-count');
+const generateBtn = document.getElementById('generate-btn');
+const quizContainer = document.getElementById('quiz-container');
+const scoreSection = document.getElementById('score-section');
+const folderSelect = document.getElementById('folder-select');
+const folderList = document.getElementById('folder-list');
+const newFolderBtn = document.getElementById('new-folder-btn');
+
+let currentQuiz = null;
+let score = 0;
+
+// Chargement des dossiers depuis le stockage local
+function loadFolders() {
+  const folders = JSON.parse(localStorage.getItem('folders') || '{}');
+  folderSelect.innerHTML = '<option value="">(aucun)</option>';
+  folderList.innerHTML = '';
+  Object.keys(folders).forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    folderSelect.appendChild(opt);
+
+    const li = document.createElement('li');
+    li.textContent = `${name} (${folders[name].length} quiz)`;
+    folderList.appendChild(li);
+  });
+}
+
+// Création d'un nouveau dossier
+newFolderBtn.addEventListener('click', () => {
+  const name = prompt('Nom du dossier :');
+  if (!name) return;
+  const folders = JSON.parse(localStorage.getItem('folders') || '{}');
+  if (!folders[name]) folders[name] = [];
+  localStorage.setItem('folders', JSON.stringify(folders));
+  loadFolders();
+});
+
+// Simulation d'appel à l'API Gemini
+async function generateQuiz() {
+  const text = courseText.value.trim();
+  if (!text) {
+    alert('Veuillez coller un texte de cours.');
+    return;
+  }
+  const count = parseInt(questionCount.value, 10);
+
+  // Exemple d'appel réel :
+  // const response = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=VOTRE_CLE', {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/json' },
+  //   body: JSON.stringify({ prompt: `Transforme ce texte en quiz de ${count || 'max'} questions: ${text}` })
+  // });
+  // const data = await response.json();
+
+  // Données simulées pour démonstration
+  const data = {
+    questions: [
+      {
+        q: 'Quel est le sujet principal du cours ?',
+        options: ['Sujet A', 'Sujet B', 'Sujet C'],
+        answer: 0
+      },
+      {
+        q: 'Quelle année est mentionnée ?',
+        options: ['2023', '2024', '2025'],
+        answer: 2
+      }
+    ]
+  };
+
+  if (count && count < data.questions.length) {
+    data.questions = data.questions.slice(0, count);
+  }
+  currentQuiz = data.questions;
+  score = 0;
+  renderQuiz();
+}
+
+generateBtn.addEventListener('click', generateQuiz);
+
+// Affichage du quiz interactif
+function renderQuiz() {
+  quizContainer.innerHTML = '';
+  currentQuiz.forEach((q, idx) => {
+    const div = document.createElement('div');
+    div.className = 'bg-white p-4 rounded shadow transition transform hover:scale-[1.01]';
+    div.innerHTML = `
+      <p class="font-medium mb-2">${idx + 1}. ${q.q}</p>
+      ${q.options.map((opt, i) => `
+        <label class="block">
+          <input type="radio" name="q${idx}" value="${i}" class="mr-2">${opt}
+        </label>`).join('')}
+      <button class="mt-2 bg-blue-500 text-white px-2 py-1 rounded" data-idx="${idx}">Valider</button>
+      <p class="mt-2 text-sm hidden" id="feedback-${idx}"></p>
+    `;
+    quizContainer.appendChild(div);
+  });
+
+  const buttons = quizContainer.querySelectorAll('button');
+  buttons.forEach(btn => btn.addEventListener('click', checkAnswer));
+}
+
+function checkAnswer(e) {
+  const idx = parseInt(e.target.dataset.idx, 10);
+  const q = currentQuiz[idx];
+  const selected = document.querySelector(`input[name="q${idx}"]:checked`);
+  const feedback = document.getElementById(`feedback-${idx}`);
+  if (!selected) {
+    alert('Choisissez une réponse');
+    return;
+  }
+  const isCorrect = parseInt(selected.value, 10) === q.answer;
+  if (isCorrect) {
+    score++;
+    feedback.textContent = 'Correct !';
+    feedback.className = 'mt-2 text-sm text-green-600';
+  } else {
+    feedback.textContent = `Incorrect. Réponse attendue : ${q.options[q.answer]}`;
+    feedback.className = 'mt-2 text-sm text-red-600';
+  }
+  feedback.classList.remove('hidden');
+  e.target.disabled = true;
+  if ([...quizContainer.querySelectorAll('button')].every(b => b.disabled)) {
+    showScore();
+    saveQuiz();
+  }
+}
+
+function showScore() {
+  scoreSection.textContent = `Score final : ${score} / ${currentQuiz.length}`;
+  scoreSection.classList.remove('hidden');
+}
+
+// Sauvegarde du quiz dans un dossier choisi
+function saveQuiz() {
+  const folder = folderSelect.value;
+  if (!folder) return;
+  const folders = JSON.parse(localStorage.getItem('folders') || '{}');
+  if (!folders[folder]) folders[folder] = [];
+  folders[folder].push({ date: new Date().toISOString(), quiz: currentQuiz });
+  localStorage.setItem('folders', JSON.stringify(folders));
+  loadFolders();
+}
+
+// Initialisation
+loadFolders();


### PR DESCRIPTION
## Summary
- add quiz.html with UI to generate quizzes from course text, select question count, and organize in folders
- add quiz.js implementing folder management, Gemini API call placeholder, interactive quiz logic with scoring

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68962ea147e0832ab2d181b033ad0580